### PR TITLE
only include css linked files containing eqcss string in filename

### DIFF
--- a/EQCSS.js
+++ b/EQCSS.js
@@ -77,7 +77,7 @@ EQCSS.load = function(){
   for(i = 0; i < styles.length; i++){
 
     // Test if the link is not read yet, and has rel=stylesheet
-    if(styles[i].getAttribute("data-eqcss-read") === null && styles[i].getAttribute("rel") == "stylesheet"){
+    if(styles[i].getAttribute("data-eqcss-read") === null && styles[i].getAttribute("rel") == "stylesheet" && styles[i].href.indexOf("eqcss") >= 0){
 
       // retrieve the file content with AJAX and process it
       if(styles[i].href){


### PR DESCRIPTION
I didn't compress the JS in this PR, but this is just an idea to limit the requests from all CSS files. I am running this in production on a Wordpress site and it is behaving as expected. Many less ajax files to load.
