### PR TITLE
Remove closing parentheses at the end of links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1045,9 +1045,9 @@
     <p>And view many more EQCSS demos on Codepen: <a href=http://codepen.io/search/pens?q=eqcss&limit=all&order=newest&depth=everything&show_forks=true><i class="ion-android-search"></i> Search EQCSS Codepen</a></p>
     <h3 id=docs>Documentation &amp; Tutorials</h3>
     <ul>
-      <li><a href=https://www.smashingmagazine.com/2016/07/how-i-ended-up-with-element-queries-and-how-you-can-use-them-today/)>The Search For The Holy Grail: How I Ended Up With Element Queries, And How You Can Use Them Today</a>
-      <li><a href=http://webdesign.tutsplus.com/tutorials/how-to-build-a-responsive-ui-component-using-element-queries--cms-27118)>How to Build a Responsive UI Component Using Element Queries</a>
-      <li><a href=http://webdesign.tutsplus.com/tutorials/element-queries-the-future-of-responsive-web-design--cms-26945)>Element Queries: the Future of Responsive Web Design</a>
+      <li><a href=https://www.smashingmagazine.com/2016/07/how-i-ended-up-with-element-queries-and-how-you-can-use-them-today/>The Search For The Holy Grail: How I Ended Up With Element Queries, And How You Can Use Them Today</a>
+      <li><a href=http://webdesign.tutsplus.com/tutorials/how-to-build-a-responsive-ui-component-using-element-queries--cms-27118>How to Build a Responsive UI Component Using Element Queries</a>
+      <li><a href=http://webdesign.tutsplus.com/tutorials/element-queries-the-future-of-responsive-web-design--cms-26945>Element Queries: the Future of Responsive Web Design</a>
       <li><a href=notes/element-queries-for-css.html>Element Queries For CSS</a></li>
       <li><a href=notes/technical-documentation.html>EQCSS v1.0.0 Technical Documentation</a></li>
       <li><a href=notes/a-parent-selector-for-css.html>A Parent Selector for CSS</a></li>


### PR DESCRIPTION
The parentheses at the end of links leads to 404 error pages. Must have been a mistake from copying from another markdown link