### PR TITLE
check that EQCSS.data[i].style is defined

### DIFF
--- a/EQCSS.js
+++ b/EQCSS.js
@@ -1115,7 +1115,7 @@ License: MIT
 
           // Update CSS block:
           // If all conditions are met: copy the CSS code from the query to the corresponding CSS block
-          if (test === true) {
+          if (test === true && EQCSS.data[i].style) {
 
             // Get the CSS code to apply to the element
             css_code = EQCSS.data[i].style;


### PR DESCRIPTION
Without this, under certain conditions on iOS, when EQCSS.data[i].style
is undefined, an error stops the code.